### PR TITLE
Update tools.py

### DIFF
--- a/symphonypy/tools.py
+++ b/symphonypy/tools.py
@@ -414,7 +414,9 @@ def transfer_labels_kNN(
         query_labels = ref_labels
 
     # TODO: predict_proba
-    adata_query.obs[query_labels] = knn.predict(adata_query.obsm[query_basis])
+    labels_pred = knn.predict(adata_query.obsm[query_basis])
+    labels_pred = labels_pred.reshape(labels_pred.shape[0], 1)
+    adata_query.obs[query_labels] = labels_pred
 
 
 def tsne(

--- a/symphonypy/tools.py
+++ b/symphonypy/tools.py
@@ -415,7 +415,8 @@ def transfer_labels_kNN(
 
     # TODO: predict_proba
     labels_pred = knn.predict(adata_query.obsm[query_basis])
-    labels_pred = labels_pred.reshape(labels_pred.shape[0], 1)
+    if isinstance(query_labels, list) and len(query_labels) == 1:
+        labels_pred = labels_pred.reshape(labels_pred.shape[0], 1)
     adata_query.obs[query_labels] = labels_pred
 
 


### PR DESCRIPTION
Using `pandas==1.5.3` and `scikit-learn==1.1.1`, running `sp.tl.tranfer_labels_kNN` as per the tutorial leads to a `ValueError: Columns must be same length as key`.

`knn.predict(adata_query.obsm[query_basis])` returns a vector of shape `(n_cells,)` but it needs to be reshaped to `(n_cells,1)` in order to add it to `adata_query.obs`.

