### PR TITLE
removed unsupported time parameter

### DIFF
--- a/symphonypy/tl.py
+++ b/symphonypy/tl.py
@@ -260,7 +260,7 @@ def ingest(
         for i, col in enumerate(obs):
             ing.map_labels(col, labeling_method[i])
 
-    logger.info("    finished", time=start)
+    logger.info("finished")
 
     if "rep" in ing._obsm:
         del ing._obsm["rep"]


### PR DESCRIPTION
I encountered the error TypeError: Logger._log() got an unexpected keyword argument 'time'. This change simply removes the unsupported time parameter from the logging call in the ingest function. 